### PR TITLE
Load voters from config

### DIFF
--- a/config/security.php
+++ b/config/security.php
@@ -31,7 +31,18 @@ return array(
   | )
   |
   */
-  'role_hierarchy' => array()
+  'role_hierarchy' => array(),
 
-
+  /*
+  |--------------------------------------------------------------------------
+  | Voters
+  |--------------------------------------------------------------------------
+  |
+  | The voters listed here will be automatically added.
+  |
+  */
+  'voters' => [
+    'Barryvdh\Security\Authorization\Voter\AuthVoter',
+    'Symfony\Component\Security\Core\Authorization\Voter\RoleHierarchyVoter',
+  ],
 );

--- a/readme.md
+++ b/readme.md
@@ -44,9 +44,16 @@ To use roles, add a function getRoles() to your User model, which returns an arr
         return $this->roles()->lists('name');
     }
 
-You can add voters by extending $app['security.voters'] or using the facade:
+You can add voters by adding them to the config.
 
-    Facade:addVoter(new MyVoter());
+    'voters' => [
+        ...
+        'App\Security\MyVoter.php',
+    ],
+
+You can also add voters by extending $app['security.voters'] or using the facade:
+
+    Security::addVoter(new MyVoter());
 
 Voters have to implement [VoterInterface](https://github.com/symfony/Security/blob/master/Core/Authorization/Voter/VoterInterface.php).
 You can define which attributes (ie. ROLE_ADMIN, IS_AUTHENTICATED, EDIT etc) and which objects the voter can handle.

--- a/src/SecurityServiceProvider.php
+++ b/src/SecurityServiceProvider.php
@@ -71,11 +71,14 @@ class SecurityServiceProvider extends ServiceProvider {
                 return new AccessDecisionManager($app['security.voters'], $app['security.strategy']);
             });
 
+        $app->bind('Symfony\Component\Security\Core\Role\RoleHierarchyInterface', function($app) {
+                return new RoleHierarchy($app['security.role_hierarchy']);
+            });
+
         $app['security.voters'] = $app->share(function ($app) {
-                return array(
-                    new RoleHierarchyVoter(new RoleHierarchy($app['security.role_hierarchy'])),
-                    new AuthVoter(),
-                );
+                return array_map(function($voter) use ($app) {
+                    return $app->make($voter);
+                }, $app['config']->get('security.voters'));
             });
 
         //Listener for Login event


### PR DESCRIPTION
I'd like to suggest loading voters from the config file automatically.

I realize this is a departure from the Silex ServiceProvider that you mentioned before. However I think it provides some nice benefits.
1. It's more Laravel-like. Think how `app/config.php` specifies service providers. Or how `app/Http/Kernel.php` specifies middleware.
2. It's easier for me (and other users) to add voters. Now I don't have to setup a separate service provider of my own just to add voters. I'm lazy, I'd much rather stick them in a config file!
3. This allows me to override/remove your two default voters if needed. This is actually a need on one of my current projects, where I have a custom AuthVoter and need to remove the default one.

I know this is more of a feature request. If you don't want this in your package I can still override `$app['security.voters']` in a custom service provider on my own if I have to. 
